### PR TITLE
Fixed multiple import name

### DIFF
--- a/flintdata/scripts/cli.py
+++ b/flintdata/scripts/cli.py
@@ -40,7 +40,6 @@ def entrypoint() -> None:
     try:
         cli(obj={})
     except Exception:
-        import logging
         logger = logging.getLogger(__name__)
         logger.exception('Uncaught exception!', exc_info=True)
         sys.exit(1)


### PR DESCRIPTION
## Description 

While browsing through the Code and studying it for better understanding, I found minor bugs and anti-patterns that can be possibly improved to mitigate any potential bug. Since this is the first time, when I'm contributing to Moja Global, I wanted to get a better understanding of the Codebase and make contributions on the same. 

## Changes Done 

The following commits have been made on the Codebase: 

- Fixing the multiple error issue

I found the `logging` package was imported twice in the same file. I fixed it according to the PEP8 standard. There were some more issues with respect to PEP8 formatting as per PyLint but I would like to know, if PEP8 is strictly enforced on the Codebase.